### PR TITLE
pad traits so that they fit neatly within the embed

### DIFF
--- a/embeds.js
+++ b/embeds.js
@@ -23,6 +23,17 @@ const beanzURL = {
   gem: `https://www.gem.xyz/asset/${contract.beanz}`,
 };
 
+function padTraits(traits) {
+  // Determines the number of traits and pads the array with blank fields to a multiple of 3
+  let padLen = 3 - (traits.length % 3);
+  var padding = new Array(padLen).fill({
+    name: '\u200b',
+    value: '\u200b',
+    inline: true,
+  })
+  return traits.concat(padding);
+}
+
 export const azukiEmbed = async function (id) {
   const [traits, list, lastSale] = await Promise.all([
     getTraits(
@@ -44,7 +55,7 @@ export const azukiEmbed = async function (id) {
         icon_url: `${azukiURL.icon}`,
       },
       fields: [
-        ...traits,
+        ...padTraits(traits),
         {
           name: "Links",
           value: `[OpenSea](${azukiURL.opensea}/${id}) | [LooksRare](${azukiURL.looksrare}/${id}) | [X2Y2](${azukiURL.x2y2}/${id}) | [SudoSwap](${azukiURL.sudoswap}/${id}) | [Gem](${azukiURL.gem}/${id})`,
@@ -81,7 +92,7 @@ export const beanzEmbed = async function (id) {
         icon_url: `${beanzURL.icon}`,
       },
       fields: [
-        ...traits,
+        ...padTraits(traits),
         {
           name: "Links",
           value: `[OpenSea](${beanzURL.opensea}/${id}) | [LooksRare](${beanzURL.looksrare}/${id}) | [X2Y2](${beanzURL.x2y2}/${id}) | [SudoSwap](${beanzURL.sudoswap}/${id}) | [Gem](${beanzURL.gem}/${id})`,


### PR DESCRIPTION
Currently, inline fields are rended in the Embed card 3 in a row. However, if there are insufficient fields, Discord will render them equally spaced which looks kinda messy IMO. This PR adds invisible inline fields to the Azuki/Beanz embed to maintain a regular spacing of fields across rows.

Note that these invisible fields aren't visible on mobile.

### Before
![image](https://user-images.githubusercontent.com/104123079/194718692-139d0a76-9769-4a46-b7ed-384d97f4dc3d.png)

### After
![image](https://user-images.githubusercontent.com/104123079/194718739-f749c5fc-3950-47ef-8347-59c87a69e5cf.png)

## References
- https://discordjs.guide/popular-topics/embeds.html#using-the-embed-constructor
    > To add a blank field to the embed, you can use `.addFields({ name: '\u200b', value: '\u200b' }).`