### PR TITLE
Add a button to allow re-rolling the village tag

### DIFF
--- a/app.js
+++ b/app.js
@@ -114,23 +114,30 @@ client.on(Events.InteractionCreate, async (interaction) => {
     if (!interaction.isButton()) return;
     if (interaction.customId) await interaction.deferUpdate();
 
+    if (interaction.customId === "village" || interaction.customId === "reroll") {
+      await villageInteraction(interaction, twitterHandles);
+      return
+    }
+
     const [{ data }] = interaction.message.embeds;
     const name = data.author.name;
     const defaultId = name.split(" ").at(1).slice(1);
 
-    if (
-      interaction.customId !== "beanz" &&
-      interaction.customId !== "selfie" &&
-      interaction.customId !== "pair"
-    )
-      await azukiInteraction(interaction, defaultId);
-
-    if (interaction.customId === "beanz" || interaction.customId === "selfie")
-      await beanzInteraction(interaction, defaultId);
-
-    if (interaction.customId === "pair") {
-      const secondId = name.split(" ").at(-1).slice(1);
-      await pairInteraction(interaction, defaultId, secondId);
+    switch (interaction.customId) {
+      case "azuki":
+      case "blue":
+      case "red":
+      case "wallpaper":
+        await azukiInteraction(interaction, defaultId);
+        return
+      case "beanz":
+      case "selfie":
+        await beanzInteraction(interaction, defaultId);
+        return
+      case "pair":
+        const secondId = name.split(" ").at(-1).slice(1);
+        await pairInteraction(interaction, defaultId, secondId);
+        return
     }
   } catch (error) {
     console.log(error);

--- a/buttons.js
+++ b/buttons.js
@@ -42,3 +42,12 @@ export const pairButton = () => [
       .setStyle(ButtonStyle.Primary)
   ),
 ];
+
+export const villageButton = () => [
+  new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId("reroll")
+      .setLabel("Reroll")
+      .setStyle(ButtonStyle.Primary)
+  ),
+]

--- a/interactions.js
+++ b/interactions.js
@@ -6,7 +6,7 @@ import {
   collectionEmbed,
   tokenEmbed,
 } from "./embeds.js";
-import { azukiButton, beanzButton, pairButton } from "./buttons.js";
+import { azukiButton, beanzButton, pairButton, villageButton } from "./buttons.js";
 import { params, shuffle } from "./helpers.js";
 
 const azukiIdRange = (id) => id >= 0 && id < 10000;
@@ -108,5 +108,6 @@ export const villageInteraction = async (interaction, twitterHandles) => {
 
   await interaction.editReply({
     content: "```\n" + handles + "\n```",
+    components: villageButton(),
   });
 };


### PR DESCRIPTION
Adds a `reroll` button to the village interaction to allow a user to re-roll the twitter handles without issuing the command again.

![image](https://user-images.githubusercontent.com/104123079/201484215-c7d063e9-9732-4361-ab07-58e3a8701135.png)


Also includes a minor refactor of the client button event logic in `app.js` to facilitate the new button.